### PR TITLE
Update 05_Plane_wave_expansion_with_autograd.ipynb

### DIFF
--- a/docs/examples/05_Plane_wave_expansion_with_autograd.ipynb
+++ b/docs/examples/05_Plane_wave_expansion_with_autograd.ipynb
@@ -375,13 +375,8 @@
     }
    ],
    "source": [
-    "# Returns objective function value and gradients\n",
-    "obj_grad = value_and_grad(of_sc)\n",
-    "\n",
-    "# Initialize an optimization object; jac=True means that obj_grad returns both the value \n",
-    "# and the jacobian of the objective. The alternative syntax with grad_a defined above\n",
-    "# would be Minimize(of_sc, jac=grad_a), but this will be slower\n",
-    "opt = Minimize(obj_grad, jac=True)\n",
+    "# Initialize an optimization object\n",
+    "opt = Minimize(of_sc)\n",
     "\n",
     "# Run the optimization\n",
     "(p_opt, ofs1) = opt.lbfgs(pstart, Nepochs=10)"


### PR DESCRIPTION
Updated notebook example 5 so it runs again. Removed Jacobian parameter for Minimize and gradient calculation is now left to be handled inside Minimize.