### PR TITLE
docs: update installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,8 +4,8 @@ Installation
 Required dependencies
 ---------------------
 
-- Python (>= 3.6)
-- `numpy <http://www.numpy.org/>`__ (>= 1.16,<2.0.0)
+- Python (>= 3.7)
+- `numpy <http://www.numpy.org/>`__ (>= 1.16.2)
 - `scipy <http://www.scipy.org/>`__ (>= 1.2.1)
 - `matplotlib <http://www.matplotlib.org/>`__ (>= 3.0.3)
 
@@ -24,7 +24,12 @@ To install the latest version of Legume from PyPi::
 
     pip install legume-gme
 
-Alternatively, you can ``git clone`` Legume from the Fan group GitHub, manually install all of the required dependencies, and add the path to the Legume in your python path environment variable::
+Alternatively, you can ``git clone`` Legume from the Fan group GitHub and install it locally with pip::
 
     git clone https://github.com/fancompute/legume.git
-    export PYTHONPATH=$PYTHONPATH:/path/to/the/location/of/legume
+    cd legume
+    pip install .
+
+To install the optional autograd dependency as well::
+
+    pip install '.[autodiff]'


### PR DESCRIPTION
## Summary
- update the documented minimum Python version to 3.7
- remove the stale NumPy <2.0.0 upper bound from the installation docs
- replace the old PYTHONPATH source-install instructions with `pip install .` and `pip install '.[autodiff]'`

## Validation
- checked the docs change against the current `master` packaging metadata in `pyproject.toml`
