### PR TITLE
release: bump version to 1.0.3

### DIFF
--- a/legume/__init__.py
+++ b/legume/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     'Poly', 'Square', 'Hexagon', 'Ellipse', 'Ring'
 ]
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "legume-gme"
-version = "1.0.2"
+version = "1.0.3"
 description = "Differentiable plane-wave and guided-mode expansion for photonic crystals"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- bump the package version from 1.0.2 to 1.0.3 in both `pyproject.toml` and `legume/__init__.py`

## Validation
- installed in a clean Python 3.12 virtualenv with `numpy 2.4.3`
- scalar `fsolve` sanity check passed for Python float, NumPy scalar, and size-1 ndarray callbacks
- `python -m pytest tests`: 13 passed
- `python -m build` and `python -m twine check dist/*` passed
